### PR TITLE
Update pre-commit

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-RELEASE=1.10.0
+RELEASE=1.13.0
 JAR_NAME="google-java-format-${RELEASE}-all-deps.jar"
 RELEASES_URL=https://repo1.maven.org/maven2/com/google/googlejavaformat/google-java-format
 JAR_URL="${RELEASES_URL}/${RELEASE}/${JAR_NAME}"
@@ -49,9 +49,14 @@ changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*
 if [[ -n "$changed_java_files" ]]
 then
     echo "Reformatting Java files: $changed_java_files"
-    if ! java -jar "$JAR_FILE" --replace --set-exit-if-changed $changed_java_files
+    if ! java   --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+                --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+                --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+                --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+                --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+                -jar "$JAR_FILE" --replace --set-exit-if-changed $changed_java_files
     then
-        echo "Some files were changed, aborting commit!" >&2
+        echo "An error occured, aborting commit!" >&2
         exit 1
     fi
 else


### PR DESCRIPTION
1. Updated to the latest version of google-java-format formatter
2. Added the work around flag for running the formatter on JDK 16+. See here  https://github.com/google/google-java-format#jdk-16
3. Adjusted  the error comment when the formatter fails, as the formatter can fail even before any source file is formatted.